### PR TITLE
Fix i18n.js locales.reverse() bug

### DIFF
--- a/jade/js/i18n.js
+++ b/jade/js/i18n.js
@@ -26,7 +26,7 @@ var i18n = (function() {
 
   var locales;
   if (navigator.languages) {
-    locales = navigator.languages;
+    locales = Array.prototype.slice.call(navigator.languages); // navigator.languages is a read-only collection: convert to new array here
   } else {
     var locale = navigator.userLanguage || navigator.language;
     if (typeof(locale) == "string") {


### PR DESCRIPTION
navigator.languages is read-only: convert to array before using locales.reverse();